### PR TITLE
Changing the default creds name to default-ibm-quantum-platform

### DIFF
--- a/qiskit-code-assistant-mcp-server/src/qiskit_code_assistant_mcp_server/utils.py
+++ b/qiskit-code-assistant-mcp-server/src/qiskit_code_assistant_mcp_server/utils.py
@@ -25,10 +25,10 @@ def _get_token_from_system():
         with open(qiskit_file, "r") as _sc:
             creds = json.loads(_sc.read())
 
-        token = creds.get("default-ibm-quantum", {}).get("token")
+        token = creds.get("default-ibm-quantum-platform", {}).get("token")
         if token is None:
             raise Exception(
-                f"default-ibm-quantum not found in {qiskit_file}. Please set env var QISKIT_IBM_TOKEN to access the service, or save your IBM Quantum API token using QiskitRuntimeService. "
+                f"default-ibm-quantum-platform not found in {qiskit_file}. Please set env var QISKIT_IBM_TOKEN to access the service, or save your IBM Quantum API token using QiskitRuntimeService. "
                 "More info about saving your token using QiskitRuntimeService https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#save_account"
             )
 

--- a/qiskit-code-assistant-mcp-server/tests/conftest.py
+++ b/qiskit-code-assistant-mcp-server/tests/conftest.py
@@ -35,7 +35,7 @@ def mock_qiskit_credentials(tmp_path):
     qiskit_dir.mkdir()
 
     credentials = {
-        "default-ibm-quantum": {
+        "default-ibm-quantum-platform": {
             "token": "test_token_from_file",
             "url": "https://auth.quantum-computing.ibm.com/api",
         }

--- a/qiskit-code-assistant-mcp-server/tests/test_utils.py
+++ b/qiskit-code-assistant-mcp-server/tests/test_utils.py
@@ -55,7 +55,7 @@ class TestGetTokenFromSystem:
         """Test exception when credentials file exists but missing default entry."""
         import json
 
-        # Create file without default-ibm-quantum entry
+        # Create file without default-ibm-quantum-platform entry
         with open(mock_qiskit_credentials, "w") as f:
             json.dump({"other-account": {"token": "other_token"}}, f)
 
@@ -65,7 +65,7 @@ class TestGetTokenFromSystem:
             with pytest.raises(Exception) as exc_info:
                 _get_token_from_system()
 
-            assert "default-ibm-quantum not found" in str(exc_info.value)
+            assert "default-ibm-quantum-platform not found" in str(exc_info.value)
 
 
 class TestGetErrorMessage:


### PR DESCRIPTION
Fixes #8 